### PR TITLE
Drop travel and todo from ID Liaison sublist.

### DIFF
--- a/elcid/schema.py
+++ b/elcid/schema.py
@@ -22,12 +22,10 @@ list_columns_id_liaison = [
     omodels.Tagging,
     models.Diagnosis,
     models.PastMedicalHistory,
-    models.Travel,
     models.Antimicrobial,
     models.MicrobiologyTest,
     models.MicrobiologyInput,
     models.GeneralNote,
-    models.Todo,
 ]
 
 list_columns_infection_control = [


### PR DESCRIPTION
refs #302 

Remove a couple of columns from the ID Liaison team view to increase screen real estate for useful columns. 
