### PR TITLE
Remove current tag, add dblclick handler refs #337

### DIFF
--- a/elcid/templates/tagging.html
+++ b/elcid/templates/tagging.html
@@ -1,6 +1,8 @@
 <span ng-repeat="tag in row.getTags()" class="screen-only">
-  <button class="btn btn-xs" ng-click="jumpToTag(tag)" ng-show="tag_display[tag] != undefined">
+  <span ng-show="tag_display[tag] != undefined && tag != currentSubTag && tag != currentTag">
+  <button class="btn btn-xs" ng-bdblclick="jumpToTag(tag)" ng-click="jumpToTag(tag)" >
     [[ tag_display[tag] ]]
   </button>
   <br />
+  </span>
 </span>


### PR DESCRIPTION
As well as adding a dblclick handler, we also stop displaying the team you're currently viewing - which is nice. 

You occasionally do get a location modal open, but I reckon that's you clicking after it's re-rendered...
