### PR TITLE
Use the existing date of discharge when we are confirming discharge.

### DIFF
--- a/elcid/assets/js/elcid/controllers.js
+++ b/elcid/assets/js/elcid/controllers.js
@@ -31,7 +31,9 @@ controllers.controller('DischargeEpisodeCtrl', function($scope, $timeout,
 
     $scope.episode = episode.makeCopy();
     if(!$scope.episode.discharge_date){
-        $scope.episode.discharge_date = moment().format('DD/MM/YYYY');
+        $scope.editing.discharge_date = moment().format('DD/MM/YYYY');
+    }else{
+        $scope.editing.discharge_date = $scope.episode.discharge_date;
     }
 
     // 


### PR DESCRIPTION
When confirming the discharge of a patient, retain the date of discharge if it is set. 

refs #315
