### PR TITLE
16 white labelling api

### DIFF
--- a/elcid/settings.py
+++ b/elcid/settings.py
@@ -169,6 +169,7 @@ INSTALLED_APPS = (
     'wardround',
     'referral',
     'dashboard',
+    'iframeapi',
 #    'opal.core.collaborative',
     'guidelines',
     'dischargesummary',

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,5 @@ django-compressor==1.5
 -e git+https://github.com/openhealthcare/opal-dashboard.git@#egg=opal_dashboard
 -e git+https://github.com/openhealthcare/opal-dischargesummary.git@v0.1#egg=opal_dischargesummary
 -e git+https://github.com/openhealthcare/opal-guidelines.git@#egg=opal_guidelines
+-e git+https://github.com/openhealthcare/opal-iframe-api.git@#egg=opal-iframe-api
 -e git+https://github.com/srosro/django-test-coverage#egg=django-test-coverage


### PR DESCRIPTION
some changes minor changes have (wrongly, but they are covered by unittests) gone into opal 0.4.2. The opal-iframe-api is all on master in that repo

