### PR TITLE
Update _title property for OPAT Outcomes so that the record panel

### DIFF
--- a/elcid/models.py
+++ b/elcid/models.py
@@ -340,6 +340,7 @@ class OPATOutcome(EpisodeSubrecord):
     differently.
     """
     _is_singleton     = True
+    _title            = "OPAT Outcome"
 
     treatment_outcome     = models.CharField(max_length=200, blank=True, null=True)
     deceased              = models.NullBooleanField(default=False)


### PR DESCRIPTION
header displays correctly in the detail view.

refs openhealthcare/opal-opat#9

@fredkingham this is not deployed anywhere, but perhaps you'll live dangerously and merge it anyway given the nature of the one line change to correct a typo?

Maybe I didn't even need a PR for this ?