### PR TITLE
use django cached template loader

### DIFF
--- a/elcid/settings.py
+++ b/elcid/settings.py
@@ -105,9 +105,10 @@ SECRET_KEY = 'hq6wg27$1pnjvuesa-1%-wiqrpnms_kx+w4g&&o^wr$5@stjbu'
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-#     'django.template.loaders.eggs.Loader',
+    ('django.template.loaders.cached.Loader', (
+        'django.template.loaders.filesystem.Loader',
+        'django.template.loaders.app_directories.Loader',
+    )),
 )
 
 MIDDLEWARE_CLASSES = (


### PR DESCRIPTION
in memory django template loader speeds loads time locally from 1.09 seconds to just 89 ms

only requirement is to be thread safe in our template tags, which I believe we are https://docs.djangoproject.com/en/1.7/ref/templates/api/