### PR TITLE
Fixes failing list tests from changes to 0.6 discoverable

### DIFF
--- a/elcid/patient_lists.py
+++ b/elcid/patient_lists.py
@@ -8,7 +8,7 @@ class Mine(PatientList):
     if the user has tagged episodes as their's this will give them the appropriate
     episode queryset
     """
-    name = 'mine'
+    display_name = 'mine'
 
     @classmethod
     def get(klass, **kwargs):

--- a/opat/patient_lists.py
+++ b/opat/patient_lists.py
@@ -16,18 +16,24 @@ list_columns_opat = [
 
 
 class OPATReferral(TaggedPatientList):
+    display_name = 'OPAT Referrals'
+    direct_add = False
     tag = "opat"
     subtag = "opat_referrals"
     schema = list_columns_opat
 
 
 class OPATFollowUp(TaggedPatientList):
+    display_name = 'OPAT Follow up'
+    direct_add = False
     tag = "opat"
     subtag = "opat_followup"
     schema = list_columns_opat
 
 
 class OPATCurrent(TaggedPatientList):
+    display_name = 'OPAT Current'
+    direct_add = False
     tag = "opat"
     subtag = "opat_current"
     schema = list_columns_opat

--- a/research/patient_lists.py
+++ b/research/patient_lists.py
@@ -4,6 +4,8 @@ from opal.core.patient_lists import TaggedPatientList
 
 
 class RidRtiScientist(TaggedPatientList):
+    display_name = 'Scientist'
+    direct_add = False
     tag = "rid_rti"
     subtag = "rid_rti_scientist"
     schema = [
@@ -16,6 +18,8 @@ class RidRtiScientist(TaggedPatientList):
 
 
 class RidRtiResearchPractitioner(TaggedPatientList):
+    display_name = 'Research Practitioner'
+    direct_add = False
     tag = "rid_rti"
     subtag = "rid_rti_research_practitioner"
     schema = [

--- a/walkin/patient_lists.py
+++ b/walkin/patient_lists.py
@@ -5,6 +5,8 @@ from opal.core.patient_lists import TaggedPatientList
 
 
 class WalkinDoctor(TaggedPatientList):
+    display_name = 'Walkin Doctor'
+    direct_add = False
     tag = "walkin"
     subtag = "walkin_doctor"
     schema = [
@@ -22,6 +24,8 @@ class WalkinDoctor(TaggedPatientList):
 
 
 class WalkinNurseTriage(TaggedPatientList):
+    display_name = 'Walkin Nurse Triage'
+    direct_add = False
     tag = "walkin"
     subtag = "walkin_triage"
     schema = [
@@ -35,6 +39,8 @@ class WalkinNurseTriage(TaggedPatientList):
 
 
 class WalkinReview(TaggedPatientList):
+    display_name = 'Walkin Review'
+    direct_add = False
     tag = "walkin"
     subtag = "walkin_review"
     schema = [


### PR DESCRIPTION
Turns out that the Discoverable changes broke elCID more than we were expecting - PRs that passed last night failed this afternoon :(

This should update *all* of the lists in elCID to have display_names and appropriate direct_add properties.