### PR TITLE
remove event ordering by haem as this is now done in the patient load…

### DIFF
--- a/elcid/assets/js/elcid/controllers/haem_view.js
+++ b/elcid/assets/js/elcid/controllers/haem_view.js
@@ -32,11 +32,6 @@ angular.module('opal.controllers').controller('HaemView', function($scope){
      return orderByDate(clinicalAdviceDate);
   };
 
-  vm.getEpisodeOrdering = function(episode){
-      var significantDate = episode.discharge_date || episode.date_of_episode || episode.date_of_admission;
-      return orderByDate(significantDate)
-  };
-
   if($scope.patient.episodes.length){
       $scope.episode.alertInvestigations = function(){
               return _.reduce($scope.patient.episodes, function(r, e){

--- a/elcid/assets/js/elcidtest/haem_view.test.js
+++ b/elcid/assets/js/elcidtest/haem_view.test.js
@@ -3,6 +3,20 @@ describe('HaemView', function() {
 
   var controller;
   var $rootScope;
+  var fakeEpisodes = [
+    {
+      id: 1,
+      when: moment(new Date(2015, 1, 1)),
+      created: moment(new Date(2014, 1, 1)),
+    },
+    {
+      id: 2
+    },
+    {
+      id: 3,
+      created: moment(new Date(2014, 1, 1)),
+    },
+  ];
 
   beforeEach(function(){
       var $controller;
@@ -18,22 +32,14 @@ describe('HaemView', function() {
   });
 
   describe("it should order an event based on an episode date hierachy", function(){
-      it("should use discharge_date as the higest priority", function(){
-          var fakeEpisode = {
-              discharge_date: moment(new Date(2015, 1, 1)),
-              date_of_episode: moment(new Date(2014, 1, 1)),
-              date_of_admission: moment(new Date(2013, 1, 1)),
-          };
-          var ordering = controller.getEpisodeOrdering(fakeEpisode);
-          expect(ordering).toBe(-1422748800);
+    it("should order clinical advice when then created by then undefined", function(){
+      var ordered_events = _.sortBy(fakeEpisodes, function(x){
+          return controller.clinicalAdviceOrdering(x);
       });
 
-      it("should use date_of_admission if no other date is available", function(){
-        var fakeEpisode = {
-            date_of_admission: moment(new Date(2015, 1, 1)),
-        };
-        var ordering = controller.getEpisodeOrdering(fakeEpisode);
-        expect(ordering).toBe(-1422748800);
-      });
+      expect(ordered_events[0].id).toBe(1);
+      expect(ordered_events[1].id).toBe(3);
+      expect(ordered_events[2].id).toBe(2);
+    });
   });
 });

--- a/elcid/templates/detail/micro_haem.html
+++ b/elcid/templates/detail/micro_haem.html
@@ -17,7 +17,7 @@
           {% record_panel models.MicrobiologyTest editable="false" title="Alert Investigation Results" name="alertInvestigations()" %}
         </div>
       </div>
-      <section ng-repeat="episode in patient.episodes | orderBy:haemView.getEpisodeOrdering">
+      <section ng-repeat="episode in patient.episodes">
         <hr class="patient-timeline-seperator">
         <div class="row">
           <div parent-height class="col-md-6">


### PR DESCRIPTION
…er, add unit tests for clinical advice ordering