### PR TITLE
Implement DRF token authentication

### DIFF
--- a/elcid/settings.py
+++ b/elcid/settings.py
@@ -160,6 +160,7 @@ INSTALLED_APPS = (
     'reversion',
     'opal',
     'rest_framework',
+    'rest_framework.authtoken',
     'compressor',
     'opal.core.search',
     'elcid',
@@ -304,6 +305,12 @@ if GLOSS_ENABLED:
 
 EXTRACT_ASYNC = True
 
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.TokenAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
+    )
+}
 
 if 'test' not in sys.argv:
     try:


### PR DESCRIPTION
This is how we would require applications to implement DRF token authentication alongside Django Session Auth for our APIs. (Described in https://github.com/openhealthcare/opal/issues/743)

It requires migrations to be run (from the new app.)

Other work would be required for 743 that include making this change for other apps, including these settings in the scaffold app, and documenting upgrade guides for 0.6.x -> 0.7.x.

You can use the [OPALAPI](https://github.com/openhealthcare/opalapi) library to test out the new token auth.