### PR TITLE
Walkin discharge remove from list

### DIFF
--- a/elcid/templates/acceptance/walkin/discharge.feature
+++ b/elcid/templates/acceptance/walkin/discharge.feature
@@ -1,0 +1,11 @@
+As a Nurse
+I need to be able to judge that a patient can be dealt with by the community nurses, and
+discharge them with a letter.
+
+Given that I am on the Walkin Nurse Triage list
+Given that there is a patient on the list
+Given I click next
+Given I don't add HIV Point of Care or Observations
+Given I click nurse led care.
+Then I fill in details and click remove from list.
+Then the patient should be removed from the list and a clinic letter brought up.

--- a/walkin/static/js/walkin/controllers/walkin_discharge.js
+++ b/walkin/static/js/walkin/controllers/walkin_discharge.js
@@ -3,8 +3,11 @@
 //
 controllers.controller(
     'WalkinDischargeCtrl',
-    function($scope, $modalInstance, $modal, $rootScope, $q,
-             growl, Item, CopyToCategory, UserProfile, referencedata, episode, tags){
+    function(
+      $scope, $modalInstance, $modal, $rootScope, $q,
+      growl, Item, CopyToCategory, UserProfile, referencedata, episode, tags,
+      $templateRequest
+    ){
 
         "use strict";
 
@@ -159,6 +162,13 @@ controllers.controller(
 
             $scope.episode.save(ep).then(function(resp){
                 $q.all(to_save).then(function(){
+                  // slight over engineering but...
+                  // we want the user to be discharged and then the discharge
+                  // summary to open.
+                  // This should be seamless for the user so we preCache
+                  // the discharge summary before moving to the next stage
+                  $templateRequest('/dischargesummary/modals/walkinnurse/').then(function(){
+                    $modalInstance.close('discharged');
                     growl.success('Removed from Walk-in lists');
                     var deferred = $q.defer();
                     var modal = $modal.open({
@@ -167,7 +177,7 @@ controllers.controller(
                         size: 'lg',
                         resolve: {episode: episode}
                     });
-                    $modalInstance.close(deferred.promise);
+                  });
                 });
             });
         };
@@ -198,6 +208,7 @@ controllers.controller(
 
             $q.all(to_save).then(function(){
                 growl.success('Removed from Walk-in lists');
+                debugger;
                 $modalInstance.close('discharged');
             });
         }

--- a/walkin/static/js/walkin/controllers/walkin_discharge.js
+++ b/walkin/static/js/walkin/controllers/walkin_discharge.js
@@ -208,7 +208,6 @@ controllers.controller(
 
             $q.all(to_save).then(function(){
                 growl.success('Removed from Walk-in lists');
-                debugger;
                 $modalInstance.close('discharged');
             });
         }


### PR DESCRIPTION
we haven't been removing the patient from the list. The discharge summary modal seems to be confusing things. So now we have it as 2 steps, discharge the patient, open the discharge summary modal.

We pre-cache the discharge summary template to the user doesn't see any massive change.