### PR TITLE
haem referral bug

### DIFF
--- a/microhaem/pathways.py
+++ b/microhaem/pathways.py
@@ -19,7 +19,8 @@ class ReferPatientPathway(WizardPathway):
         ),
         Step(
             model=Diagnosis,
-            base_template="pathways/base_steps/diagnosis.html"
+            base_template="pathways/base_steps/diagnosis.html",
+            delete_others=False
         )
     )
 

--- a/microhaem/tests/test_pathways.py
+++ b/microhaem/tests/test_pathways.py
@@ -54,6 +54,39 @@ class HaemPathwayTestCase(OpalTestCase):
             ["something", "micro_haem"]
         )
 
+    def test_save_with_episode_with_diagnosis(self):
+        old_patient, old_episode = self.new_patient_and_episode_please()
+        diagnosis = old_episode.diagnosis_set.create()
+        diagnosis.condition = "cough"
+        diagnosis.save()
+        old_episode.set_tag_names(["something"], self.user)
+        self.pathway.save({
+            "demographics": [{"hospital_number": "100"}],
+            "diagnosis": [{"condition": "sick"}]
+        }, user=self.user, patient=old_patient)
+        patient = Patient.objects.get()
+        episode = patient.episode_set.first()
+        self.assertEqual(
+            patient.demographics_set.first().hospital_number,
+            "100"
+        )
+        self.assertEqual(
+            episode.diagnosis_set.count(),
+            2
+        )
+        self.assertEqual(
+            episode.diagnosis_set.first().condition,
+            "cough"
+        )
+        self.assertEqual(
+            episode.diagnosis_set.last().condition,
+            "sick"
+        )
+        self.assertEqual(
+            list(episode.get_tag_names(None)),
+            ["something", "micro_haem"]
+        )
+
     def test_redirect_url(self):
         patient, _ = self.new_patient_and_episode_please()
         self.assertEqual(


### PR DESCRIPTION
One of those bugs that you realise in the middle of the night and makes you sit up in fear.

Not perfect, the referral path in RFH is better because it updates the location in real time when the user clicks over. 

This will imitate the existing pathway, which means that someone may enter a duplicate diagnosis, however until I finish the generic way of doing things. This is an improvement.