### PR TITLE
Though you may see their’s written even by native speakers, it is inc…

### DIFF
--- a/elcid/patient_lists.py
+++ b/elcid/patient_lists.py
@@ -22,7 +22,7 @@ class ElcidPatientList(PatientList, AbstractBase):
 
 class Mine(ElcidPatientList, TaggedPatientList):
     """
-    if the user has tagged episodes as their's this will give them the
+    if the user has tagged episodes as theirs this will give them the
     appropriate
     episode queryset
     """


### PR DESCRIPTION
…orrect. Theirs should never have an apostrophe.

Theirs is the third person plural possessive pronoun – it replaces their + noun.
Is this yours or theirs?
He found a book – is it theirs?
I can’t find my keys, but theirs are on the table.
Theirs is a better idea.
Theirs is over here.

Ref: http://www.elearnenglishlanguage.com/blog/english-mistakes/theirs/