### PR TITLE
1557 do not show discharge episode on mine

### DIFF
--- a/elcid/__init__.py
+++ b/elcid/__init__.py
@@ -40,7 +40,6 @@ class Application(application.OpalApplication):
 
     actions = [
         'actions/presenting_complaint.html',
-        'actions/mine.html'
     ]
 
     patient_view_forms = {

--- a/elcid/patient_lists.py
+++ b/elcid/patient_lists.py
@@ -30,6 +30,7 @@ class Mine(ElcidPatientList, TaggedPatientList):
     tag = "mine"
     order = 100
     schema = list_columns
+    template_name = 'mine.html'
 
     @classmethod
     def get(klass, **kwargs):

--- a/elcid/templates/mine.html
+++ b/elcid/templates/mine.html
@@ -10,4 +10,4 @@
   </button>
 </p>
 {% endblock %}
-opal
+

--- a/elcid/templates/mine.html
+++ b/elcid/templates/mine.html
@@ -1,0 +1,13 @@
+{% extends "patient_lists/spreadsheet_list.html" %}
+<!-- extends opal/templates/patient_lists/spreadsheet_list.html -->
+
+{% block episode_actions %}
+<p ng-show="listView && currentTag === 'mine' && !profile.readonly">
+  <button class="screen-only btn btn-primary"
+    ng-click="removeFromMine(episode)">
+    <i class="fa fa-minus-square-o"></i>
+     Remove from 'Mine' List
+  </button>
+</p>
+{% endblock %}
+opal

--- a/elcid/templates/mine.html
+++ b/elcid/templates/mine.html
@@ -2,12 +2,12 @@
 <!-- extends opal/templates/patient_lists/spreadsheet_list.html -->
 
 {% block episode_actions %}
-<p ng-show="listView && currentTag === 'mine' && !profile.readonly">
-  <button class="screen-only btn btn-primary"
-    ng-click="removeFromMine(episode)">
-    <i class="fa fa-minus-square-o"></i>
-     Remove from 'Mine' List
-  </button>
-</p>
+<li class="list-group-item">
+  <p ng-show="listView && currentTag === 'mine' && !profile.readonly">
+    <button class="screen-only btn btn-primary"
+      ng-click="removeFromMine(episode)">
+      <i class="fa fa-minus-square-o"></i> Remove from Mine
+    </button>
+  </p>
+</li>
 {% endblock %}
-opal


### PR DESCRIPTION
* removes 'mine' from the action lilst in `__init__.py`
* changes the template used for the 'Mine' PatientList so that we can suppress the display of the 'Discharge' button.
* adds 'templates/mine.html' which `extends` the amended 'opal/templates/patient_lists/spreadsheet_list.html'

REQUIRES UPSTREAM OPAL CHANGE TO BE MERGED
PR: https://github.com/openhealthcare/opal/pull/1473
Branch: https://github.com/openhealthcare/opal/tree/elcid-1557-do-not-show-discharge-episode-on-mine

