### PR TITLE
remove the reference to episode history as it is not necessary

### DIFF
--- a/elcid/wardrounds.py
+++ b/elcid/wardrounds.py
@@ -17,7 +17,6 @@ class HistoricTagsMixin(object):
                     episodes=Episode.objects.serialised(
                         self.request.user,
                         self.episodes(),
-                        episode_history=True,
                         historic_tags=True),
                     )
 


### PR DESCRIPTION
We no longer use this flag and it is being remove in opal with 
https://github.com/openhealthcare/opal/pull/1491